### PR TITLE
Reduce request timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Use `--max-items` and `--delay` to control crawl size and politeness. The
 By default the crawler processes at most 500 XML files with a 0.2 second delay
 between requests.
 
+Each HTTP request has a 15 second timeout and is retried twice. This prevents
+the workflow from hanging indefinitely when the server is unresponsive.
+
 
 OCR data is retrieved via the service's ZIP archives when possible to minimise
 the number of HTTP requests.

--- a/crawler_for_sgd.py
+++ b/crawler_for_sgd.py
@@ -40,10 +40,11 @@ HEADERS = {
 }
 DEFAULT_DELAY = 0.2  # polite crawl delay (seconds)
 PAGE_RETRIES = Retry(
-    total=5,
-    backoff_factor=1.5,
+    total=2,
+    backoff_factor=1.0,
     status_forcelist=[500, 502, 503, 504],
 )
+REQUEST_TIMEOUT = 15  # seconds per request
 DEFAULT_MAX_ITEMS = 500  # cap the crawl to avoid CI timeouts
 VISITED_FILE = "visited.txt"
 
@@ -65,7 +66,7 @@ class BaseCrawler:
         """GET a path relative to BASE_URL and return BeautifulSoup."""
         url = f"{BASE_URL}{path}"
         for attempt in range(3):
-            resp = self.session.get(url, timeout=30)
+            resp = self.session.get(url, timeout=REQUEST_TIMEOUT)
             if resp.ok:
                 return BeautifulSoup(resp.text, "lxml")
             logging.warning("Retry %s for %s (%s)", attempt, url, resp.status_code)


### PR DESCRIPTION
## Summary
- shorten request timeout and retry count to avoid long hangs
- document the shorter timeout in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685b95587d248329819572857b922d54