### PR TITLE
Fix documentation and add request timeouts

### DIFF
--- a/.github/workflows/sgd-crawler.yml
+++ b/.github/workflows/sgd-crawler.yml
@@ -45,7 +45,7 @@ jobs:
           git config --global user.email 'github-actions@github.com'
           # Check if there are changes to commit
           if [ -n "$(git status --porcelain)" ]; then
-            git add data/*.jsonl
+            git add data/*.jsonl || true
             git commit -m "Data: Add new batch from Statengeneraal Digitaal"
             git push
           else

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The included GitHub workflow runs daily and keeps track of processed files
 using a cached `visited.txt`. Results are uploaded to the public dataset
 `vGassen/Dutch-Statengeneraal-Digitaal-Historical`.
 
-See `.github/workflows/sgd.yml` for a complete example.
+See `.github/workflows/sgd-crawler.yml` for a complete example.
 
 ## Dependencies
 

--- a/scripts/sgd_crawler.py
+++ b/scripts/sgd_crawler.py
@@ -47,7 +47,7 @@ def get_year_links():
     This is a simple parsing of the main directory page.
     """
     try:
-        response = requests.get(BASE_URL, headers=HEADERS)
+        response = requests.get(BASE_URL, headers=HEADERS, timeout=15)
         response.raise_for_status()
         # A simple way to find links that look like years
         links = etree.HTML(response.content).xpath('//a/@href')
@@ -67,7 +67,7 @@ def get_work_links(year_url):
     Fetches links to the individual 'works' for a given year.
     """
     try:
-        response = requests.get(year_url, headers=HEADERS)
+        response = requests.get(year_url, headers=HEADERS, timeout=15)
         response.raise_for_status()
         links = etree.HTML(response.content).xpath('//a/@href')
         work_links = []
@@ -94,7 +94,7 @@ def process_work(work_url):
     extracted_data = []
 
     try:
-        response = requests.get(zip_url, headers=HEADERS, stream=True)
+        response = requests.get(zip_url, headers=HEADERS, stream=True, timeout=15)
         response.raise_for_status()
 
         with zipfile.ZipFile(io.BytesIO(response.content)) as z:


### PR DESCRIPTION
## Summary
- fix workflow filename in README
- add `timeout=15` to requests in `sgd_crawler.py`
- avoid error if `data/` has no files in workflow

## Testing
- `python -m py_compile scripts/sgd_crawler.py`

------
https://chatgpt.com/codex/tasks/task_e_685eadcd7ffc8329a3bbf8d2e5872edd