### PR TITLE
Handle non-standard year directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ politeness. The `--resume` flag continues from a previous run using
 Progress is tracked in this file, which is cached between runs and excluded
 from version control.
 
+Year directories on the portal do not always use a simple four digit format.
+Some are ranges such as `18141815` or include suffixes like `1815I`.
+The crawler therefore accepts any directory that starts with a four digit year.
+
 By default the crawler processes at most 500 XML files with a 0.2 second delay
 between requests.
 

--- a/scripts/sgd_crawler.py
+++ b/scripts/sgd_crawler.py
@@ -62,10 +62,13 @@ def get_year_links():
         links = etree.HTML(response.content).xpath('//a/@href')
         year_links = []
         for link in links:
-            # Assuming year directories are numeric or in a specific format
+            # Year directories can be plain numbers (e.g. ``1814``) or
+            # ranges/suffixes such as ``18141815`` or ``1815I``.  The portal
+            # always starts these names with a four digit year, so accept any
+            # link that begins with four digits.
             year = link.strip('/').split('/')[-1]
-            if year.isdigit() and len(year) == 4:
-                 year_links.append(f"{BASE_URL}/{year}/")
+            if year[:4].isdigit():
+                year_links.append(f"{BASE_URL}/{year}/")
         return sorted(list(set(year_links)))
     except requests.exceptions.RequestException as e:
         print(f"Error fetching year links: {e}")


### PR DESCRIPTION
## Summary
- support year folders with ranges and suffixes when crawling
- document year naming quirks in README

## Testing
- `python -m py_compile scripts/sgd_crawler.py`

------
https://chatgpt.com/codex/tasks/task_e_68624bb430ac8329aedc90b385ca7f54