### PR TITLE
Enable concurrent work processing

### DIFF
--- a/.github/workflows/sgd-crawler.yml
+++ b/.github/workflows/sgd-crawler.yml
@@ -37,7 +37,7 @@ jobs:
           restore-keys: visited-
 
       - name: Run crawler script
-        run: python scripts/sgd_crawler.py --resume
+        run: python scripts/sgd_crawler.py --resume --workers 4
 
       - name: Commit and push changes
         run: |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ python scripts/sgd_crawler.py --max-items 1000 --delay 0.5 --years 5 --resume
 ```
 
 Use `--max-items`, `--delay` and `--years` to control crawl size and
-politeness. The `--resume` flag continues from a previous run using
+politeness. The optional `--workers` argument processes multiple works in
+parallel. The `--resume` flag continues from a previous run using
 `visited.txt`.
 Progress is tracked in this file, which is cached between runs and excluded
 from version control.


### PR DESCRIPTION
## Summary
- add optional `--workers` argument and ThreadPoolExecutor support
- document concurrency option in README
- run crawler with `--workers 4` in the GitHub workflow

## Testing
- `python -m py_compile scripts/sgd_crawler.py`

------
https://chatgpt.com/codex/tasks/task_e_68624f5aa2048329bdcdbb397524f785