### PR TITLE
Fix shard uploads and persist numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ The crawler therefore accepts any directory that starts with a four digit year.
 By default the crawler processes at most 500 XML files with a 0.2 second delay
 between requests.
 
-The crawler writes newline-delimited JSON batches to the `data/` directory,
-producing files like `sgd_batch_001.jsonl`.
+The crawler writes newline-delimited JSON shards to the `data/` directory,
+producing files like `sgd_shard_1.jsonl`. The next shard number is persisted
+in `state.json` so new runs append files instead of overwriting existing ones.
 
 When both `HF_TOKEN` and `HF_DATASET_REPO` are set, newly created batches are
 uploaded to the specified Hugging Face dataset repository. The script will

--- a/state.json
+++ b/state.json
@@ -1,1 +1,1 @@
-{"start": 10301}
+{"start": 10301, "next_shard": 21}


### PR DESCRIPTION
## Summary
- keep track of the next shard number in `state.json`
- reuse this number when writing shards so filenames never repeat
- upload all local shard files on every run
- document persistent shard numbering in the README

## Testing
- `python -m py_compile crawler.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_b_6875180f59c4832f805153d29f205de3